### PR TITLE
Fix for "Writing the result of evaluated expressions" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Directives
 * Writing the result of evaluated expressions:
 
   ```javascript
-  var version = // #put '"'+VERSION+'";"
+  var version = // #put '"'+VERSION+'";"'
   var str = // #put "\"Hello world!\";"
   var onePlusOne = // #put (1+1)+";"
   ```


### PR DESCRIPTION
In the current example "Writing the result of evaluated expressions" for "VERSIONS", the example is missing a single quote at the end of the line. This is causing an error when that line is evaluated.

SyntaxError: Unexpected token ILLEGAL
    at Preprocessor.evaluate (/usr/local/lib/node_modules/preprocessor/Preprocessor.js:170:25)
