### PR TITLE
Fixing error in include documentation

### DIFF
--- a/Preprocessor.js
+++ b/Preprocessor.js
@@ -77,7 +77,7 @@
      * #include "path/to/file". Requires node.js' "fs" module.
      * @type {RegExp}
      */
-    Preprocessor.INCLUDE = /include[ ]+"([^"\\]*(\\.[^"\\]*)*)"[ ]*\r?\n/g;
+    Preprocessor.INCLUDE = /include[ ]+"([^"\\]*(\\.[^"\\]*)*)"[ ]*(?:\r|\n|$)/g;
 
     /**
      * #ifdef/#ifndef SOMEDEFINE, #if EXPRESSION

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Directives
 
  ```javascript
  ...
- // #include "path/to/file.js"`
+ // #include "path/to/file.js"
  ...
  ```
 


### PR DESCRIPTION
When I run the example I get the following error. The error goes away when I remove the "`" character.

/usr/local/lib/node_modules/preprocessor/Preprocessor.js:195
                        throw(new Error("Illegal #"+match[2]+": "+this.source.
                              ^
Error: Illegal #include: // #include "include.js"`

...
    at Preprocessor.process (/usr/local/lib/node_modules/preprocessor/Preprocessor.js:195:31)
