### PR TITLE
fix #14: rawgit.com to view docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Downloads
 
 Documentation
 -------------
-* [View documentation](http://htmlpreview.github.com/?http://github.com/dcodeIO/Preprocessor.js/master/docs/Preprocessor.html)
+* [View documentation](https://rawgit.com/dcodeIO/Preprocessor.js/master/docs/Preprocessor.html)
 
 Tests (& Examples) [![Build Status](https://travis-ci.org/dcodeIO/Preprocessor.js.png?branch=master)](https://travis-ci.org/dcodeIO/Preprocessor.js)
 ------------------


### PR DESCRIPTION
https://rawgit.com/dcodeIO/Preprocessor.js/master/docs/Preprocessor.html
